### PR TITLE
Backend9: introduced swagger into the app

### DIFF
--- a/iChef-WebApi/pom.xml
+++ b/iChef-WebApi/pom.xml
@@ -88,7 +88,17 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 			<version>2.5.6</version>
 		</dependency>
-
+		<!--Swagger Dependency-->
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/iChef-WebApi/src/main/java/com/kitchen/iChef/Config/SwaggerConfig.java
+++ b/iChef-WebApi/src/main/java/com/kitchen/iChef/Config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.kitchen.iChef.Config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/iChef-WebApi/src/main/resources/application.properties
+++ b/iChef-WebApi/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.datasource.password=1234
 spring.thymeleaf.enabled=false
 
 server.servlet.context-path= /kitchen
+server.port=8080
 
 spring.servlet.multipart.max-file-size=1024KB
 spring.servlet.multipart.max-request-size=1024KB


### PR DESCRIPTION
# Justification

#9 
Needed a better way to test the endpoints

# Implementation

Introduced Swagger (and added port into the properties file)

# Testing

example on how to run it  :after you run the app , enter on this link on your browser:
http://localhost:8080/kitchen/swagger-ui/
8080 is the port

# Checklist

- [ ] I tested changes to product code in product
- [ ] I considered updates to the README
- [ ] I considered updates to the error code dictionary
