### PR TITLE
backend105: bug fix measurement unit

### DIFF
--- a/iChef-WebApi/src/main/java/com/kitchen/iChef/Controller/Model/Request/RecipeIngredientRequest.java
+++ b/iChef-WebApi/src/main/java/com/kitchen/iChef/Controller/Model/Request/RecipeIngredientRequest.java
@@ -1,15 +1,11 @@
 package com.kitchen.iChef.Controller.Model.Request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.beans.factory.annotation.Required;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Null;
 
 @Getter
 @Setter

--- a/iChef-WebApi/src/main/java/com/kitchen/iChef/Controller/Model/Request/RecipeIngredientRequest.java
+++ b/iChef-WebApi/src/main/java/com/kitchen/iChef/Controller/Model/Request/RecipeIngredientRequest.java
@@ -1,11 +1,15 @@
 package com.kitchen.iChef.Controller.Model.Request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.beans.factory.annotation.Required;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Null;
 
 @Getter
 @Setter
@@ -18,6 +22,5 @@ public class RecipeIngredientRequest {
     @Min(value = 1, message = "The ingredient amount is not valid!")
     private int amount;
 
-    @NotBlank(message = "The measurementUnit is not valid!")
     private String measurementUnit;
 }


### PR DESCRIPTION
# Justification

#105 

# Implementation

We can remove the measurement unit from Json request. If we remove this field, in the database the measurement unit will be saved as null.

# Testing

http://localhost:8080/kitchen/swagger-ui/

# Checklist

- [ ] I tested changes to product code in product
- [ ] I considered updates to the README
- [ ] I considered updates to the error code dictionary
